### PR TITLE
Fix crash for invalid part number in Mesh Inspector

### DIFF
--- a/FFXIV_TexTools/Views/Models/MeshInspectorView.xaml.cs
+++ b/FFXIV_TexTools/Views/Models/MeshInspectorView.xaml.cs
@@ -171,7 +171,7 @@ namespace FFXIV_TexTools.Views.Models
             MeshPartsRichTextBox.Document.Blocks.Clear();
 
             var selectedMeshNum = (int)MeshNumComboBox.SelectedItem;
-            var selectedPartNum = (int)PartNumComboBox.SelectedItem;
+            var selectedPartNum = PartNumComboBox.SelectedItem == null ? 0 : (int)PartNumComboBox.SelectedItem;
 
             var meshPart = _meshDataList[selectedMeshNum].MeshPartList[selectedPartNum];
 


### PR DESCRIPTION
Steps to reproduce the crash:
* Open the mesh inspector on any model with multiple meshes.
* Select a mesh with multiple parts.
* Select the last part in the list.
* Select a mesh with less parts.

`PartNumComboBox` now has less items than the selected index which leads to `PartNumComboBox.SelectedItem` being `null`. The cast to `int` then throws an exception. This change instead selects the first part.

I'm submitting this PR against the master branch since I can't get develop to compile. Given that this is a simple one-line change, it should be easy to (manually?) apply to develop instead. Just thought this was the easiest way to submit the fix.