### PR TITLE
Disable toggle for matadded textures

### DIFF
--- a/FFXIV_TexTools/ViewModels/ModelViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModelViewModel.cs
@@ -559,6 +559,7 @@ namespace FFXIV_TexTools.ViewModels
                     ModStatusToggleEnabled = true;
                     ModToggleText = UIStrings.Enable;
                     break;
+                case XivModStatus.MatAdd:
                 case XivModStatus.Original:
                 default:
                     ModStatusToggleEnabled = false;

--- a/FFXIV_TexTools/ViewModels/TextureViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/TextureViewModel.cs
@@ -1017,6 +1017,7 @@ namespace FFXIV_TexTools.ViewModels
                     ModStatusToggleEnabled = true;
                     ModToggleText = UIStrings.Enable;
                     break;
+                case XivModStatus.MatAdd:
                 case XivModStatus.Original:
                 default:
                     ModStatusToggleEnabled = false;

--- a/FFXIV_TexTools/Views/ModListView.xaml.cs
+++ b/FFXIV_TexTools/Views/ModListView.xaml.cs
@@ -101,7 +101,16 @@ namespace FFXIV_TexTools.Views
             {
                 (DataContext as ModListViewModel).ModToggleText = selectedModItem.ModItem.enabled ? FFXIV_TexTools.Resources.UIStrings.Disable : FFXIV_TexTools.Resources.UIStrings.Enable;
 
-                modToggleButton.IsEnabled = true;
+                // If mod offset and original offset are the same then it's a matadded texture
+                if(selectedModItem.ModItem.data.modOffset == selectedModItem.ModItem.data.originalOffset)
+                {
+                    // Disable toggle button since toggling does nothing with equal offsets
+                    modToggleButton.IsEnabled = false;
+                }
+                else
+                {
+                    modToggleButton.IsEnabled = true;
+                }                
                 modDeleteButton.IsEnabled = true;
             }
 
@@ -136,6 +145,8 @@ namespace FFXIV_TexTools.Views
             {
                 foreach (ModListViewModel.ModListModel selectedModItem in ModItemList.SelectedItems)
                 {
+                    // If mod offset is equal to original offset there is no point in toggling as is the case for matadd textures
+                    if (selectedModItem.ModItem.data.modOffset == selectedModItem.ModItem.data.originalOffset) continue;
                     if (selectedModItem.ModItem.enabled)
                     {
                         await modding.ToggleModStatus(selectedModItem.ModItem.fullPath, false);

--- a/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml.cs
@@ -209,7 +209,7 @@ namespace FFXIV_TexTools.Views
                         }
                     }
 
-                    if (isActive == XivModStatus.Enabled)
+                    if (isActive == XivModStatus.Enabled || isActive == XivModStatus.MatAdd)
                     {
                         active = true;
                     }

--- a/FFXIV_TexTools/Views/ModPack/SimpleModPackImporter.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/SimpleModPackImporter.xaml.cs
@@ -205,7 +205,7 @@ namespace FFXIV_TexTools.Views
                         }
                     }
 
-                    if (isActive == XivModStatus.Enabled)
+                    if (isActive == XivModStatus.Enabled || isActive == XivModStatus.MatAdd)
                     {
                         active = true;
                     }


### PR DESCRIPTION
**The issue:**
It is possible for TexTools to crash if you misclick and disable a texture right after adding a new material. Textures added to an item through material addition end up with their mod offset being the same as their original offset. As a result of this toggling these mods has no real effect as it simply sets the indices to the same offset, but it still calls a bunch of other functions in the process.

**My solution:**
I've added checks so that if the modOffset and originalOffset of a modded item is the same, the toggle button gets disabled. This prevents misclicks leading to crashes and unnecessary execution of code.

This PR should be merged together with https://github.com/liinko/xivModdingFramework/pull/32