### PR TITLE
Update views on modlist close or modpack import

### DIFF
--- a/FFXIV_TexTools/MainWindow.xaml.cs
+++ b/FFXIV_TexTools/MainWindow.xaml.cs
@@ -458,7 +458,11 @@ namespace FFXIV_TexTools
         private async Task<int> ImportModpack(DirectoryInfo path, DirectoryInfo modPackDirectory, bool silent = false, bool messageInImport = false)
         {
             var importError = false;
-            
+            var textureView = TextureTabItem.Content as TextureView;
+            var textureViewModel = textureView.DataContext as TextureViewModel;
+            var modelView = ModelTabItem.Content as ModelView;
+            var modelViewModel = modelView.DataContext as ModelViewModel;
+
             try
             {
                 var ttmp = new TTMP(modPackDirectory, XivStrings.TexTools);
@@ -480,7 +484,7 @@ namespace FFXIV_TexTools
                     try
                     {
                         var importWizard = new ImportModPackWizard(ttmpData.ModPackJson, ttmpData.ImageDictionary,
-                            path, messageInImport);
+                            path, textureViewModel, modelViewModel, messageInImport);
 
                         if (messageInImport)
                         {
@@ -508,7 +512,7 @@ namespace FFXIV_TexTools
                     try
                     {
                         var simpleImport = new SimpleModPackImporter(path,
-                            ttmpData.ModPackJson, silent, messageInImport);
+                            ttmpData.ModPackJson, textureViewModel, modelViewModel, silent, messageInImport);
 
                         if (messageInImport)
                         {
@@ -536,7 +540,7 @@ namespace FFXIV_TexTools
             {
                 if (!importError)
                 {
-                    var simpleImport = new SimpleModPackImporter(path, null, silent, messageInImport);
+                    var simpleImport = new SimpleModPackImporter(path, null, textureViewModel, modelViewModel, silent, messageInImport);
 
                     if (messageInImport)
                     {

--- a/FFXIV_TexTools/MainWindow.xaml.cs
+++ b/FFXIV_TexTools/MainWindow.xaml.cs
@@ -366,7 +366,12 @@ namespace FFXIV_TexTools
         /// </summary>
         private void Menu_ModList_Click(object sender, RoutedEventArgs e)
         {
-            var modListView = new ModListView {Owner = this};
+            var textureView = TextureTabItem.Content as TextureView;
+            var textureViewModel = textureView.DataContext as TextureViewModel;
+            var modelView = ModelTabItem.Content as ModelView;
+            var modelViewModel = modelView.DataContext as ModelViewModel;
+
+            var modListView = new ModListView(textureViewModel, modelViewModel) {Owner = this};
             modListView.Show();
         }
 

--- a/FFXIV_TexTools/Views/ModListView.xaml.cs
+++ b/FFXIV_TexTools/Views/ModListView.xaml.cs
@@ -40,9 +40,14 @@ namespace FFXIV_TexTools.Views
     public partial class ModListView
     {
         private CancellationTokenSource _cts;
+        private TextureViewModel _textureViewModel;
+        private ModelViewModel _modelViewModel;
 
-        public ModListView()
+        public ModListView(TextureViewModel textureViewModel, ModelViewModel modelViewModel)
         {
+            _textureViewModel = textureViewModel;
+            _modelViewModel = modelViewModel;
+
             InitializeComponent();
         }
 
@@ -199,6 +204,14 @@ namespace FFXIV_TexTools.Views
         {
             (DataContext as ModListViewModel).Dispose();
             _cts?.Dispose();
+            if (_textureViewModel.SelectedPart != null)
+            {
+                _textureViewModel.SelectedPart = _textureViewModel.SelectedPart;
+            }
+            if(_modelViewModel.SelectedPart != null)
+            {
+                _modelViewModel.SelectedPart = _modelViewModel.SelectedPart;
+            }         
         }
     }
 }

--- a/FFXIV_TexTools/Views/ModPack/ImportModPackWizard.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/ImportModPackWizard.xaml.cs
@@ -15,6 +15,7 @@
 
 using FFXIV_TexTools.Helpers;
 using FFXIV_TexTools.Resources;
+using FFXIV_TexTools.ViewModels;
 using MahApps.Metro.Controls.Dialogs;
 using SixLabors.ImageSharp;
 using System;
@@ -41,14 +42,18 @@ namespace FFXIV_TexTools.Views
         private readonly Dictionary<string, Image> _imageDictionary;
         private readonly ModPack _modPackEntry;
         private readonly bool _messageInImport;
+        private TextureViewModel _textureViewModel;
+        private ModelViewModel _modelViewModel;
 
-        public ImportModPackWizard(ModPackJson modPackJson, Dictionary<string, Image> imageDictionary, DirectoryInfo modPackDirectory, bool messageInImport = false)
+        public ImportModPackWizard(ModPackJson modPackJson, Dictionary<string, Image> imageDictionary, DirectoryInfo modPackDirectory, TextureViewModel textureViewModel, ModelViewModel modelViewModel, bool messageInImport = false)
         {
             InitializeComponent();
 
             _imageDictionary = imageDictionary;
             _modPackDirectory = modPackDirectory;
             _messageInImport = messageInImport;
+            _textureViewModel = textureViewModel;
+            _modelViewModel = modelViewModel;
 
             ModPackNameLabel.Content = modPackJson.Name;
             ModPackAuthorLabel.Content = modPackJson.Author;
@@ -132,6 +137,16 @@ namespace FFXIV_TexTools.Views
             catch (Exception ex)
             {
 
+            }
+
+            // When the window is closed force an update of the Texture/Model tabs by setting the selected parts
+            if (_textureViewModel.SelectedPart != null)
+            {
+                _textureViewModel.SelectedPart = _textureViewModel.SelectedPart;
+            }
+            if (_modelViewModel.SelectedPart != null)
+            {
+                _modelViewModel.SelectedPart = _modelViewModel.SelectedPart;
             }
         }
 

--- a/FFXIV_TexTools/Views/ModPack/SimpleModPackImporter.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/SimpleModPackImporter.xaml.cs
@@ -15,6 +15,7 @@
 
 using FFXIV_TexTools.Helpers;
 using FFXIV_TexTools.Resources;
+using FFXIV_TexTools.ViewModels;
 using MahApps.Metro.Controls.Dialogs;
 using System;
 using System.Collections.Generic;
@@ -54,12 +55,14 @@ namespace FFXIV_TexTools.Views
         private int _modCount;
         private long _modSize;
         private bool _messageInImport, _indexLockStatus;
+        private TextureViewModel _textureViewModel;
+        private ModelViewModel _modelViewModel;
 
         [DllImport("Shlwapi.dll", CharSet = CharSet.Auto)]
         public static extern long StrFormatByteSize(long fileSize, [MarshalAs(UnmanagedType.LPTStr)] StringBuilder buffer, int bufferSize);
 
 
-        public SimpleModPackImporter(DirectoryInfo modPackDirectory, ModPackJson modPackJson, bool silent = false, bool messageInImport = false)
+        public SimpleModPackImporter(DirectoryInfo modPackDirectory, ModPackJson modPackJson, TextureViewModel textureViewModel, ModelViewModel modelViewModel, bool silent = false, bool messageInImport = false)
         {
             InitializeComponent();
 
@@ -68,6 +71,8 @@ namespace FFXIV_TexTools.Views
             _texToolsModPack = new TTMP(new DirectoryInfo(Properties.Settings.Default.ModPack_Directory),
                 XivStrings.TexTools);
             _messageInImport = messageInImport;
+            _textureViewModel = textureViewModel;
+            _modelViewModel = modelViewModel;
 
             var index = new Index(_gameDirectory);
 
@@ -642,6 +647,16 @@ namespace FFXIV_TexTools.Views
             {
                 await this.ShowMessageAsync(UIMessages.ImportCompleteTitle,
                     string.Format(UIMessages.SuccessfulImportCountMessage, TotalModsImported));
+            }
+
+            // When the import is done force an update of the Texture/Model tabs by setting the selected parts
+            if (_textureViewModel.SelectedPart != null)
+            {
+                _textureViewModel.SelectedPart = _textureViewModel.SelectedPart;
+            }
+            if (_modelViewModel.SelectedPart != null)
+            {
+                _modelViewModel.SelectedPart = _modelViewModel.SelectedPart;
             }
 
             DialogResult = true;


### PR DESCRIPTION
Currently when you import a modpack or open the mod list and delete/disable mods and then close the modlist the Texture/Model tab does not change. A manual reload by switching tabs or items is necessary to view the changes made on import or in the modlist. To force an update of the Texture/Model tab I set the selected part of those tabs upon importing a mod or closing the modlist which then forces a reload of the tabs by the setter to instantly reflect those changes. It's a bit of a roundabout solution to the problem so I'd understand if you'd prefer to implement a cleaner way to do this.