### PR TITLE
Sort modded items and modpacks in modlist alphabetically

### DIFF
--- a/FFXIV_TexTools/ViewModels/ModListViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModListViewModel.cs
@@ -125,7 +125,7 @@ namespace FFXIV_TexTools.ViewModels
 
                     category.Categories.Add(categoryItem);
                 }
-
+                category.Categories = new ObservableCollection<Category>(category.Categories.OrderBy(i => i.Name));
                 Application.Current.Dispatcher.Invoke(() => Categories.Add(category));
 
                 // Mods
@@ -167,7 +167,7 @@ namespace FFXIV_TexTools.ViewModels
                         category.Categories.Add(categoryItem);
                         category.CategoryList.Add(modItem.name);
                     }
-
+                    category.Categories = new ObservableCollection<Category>(category.Categories.OrderBy(i => i.Name));
                     Application.Current.Dispatcher.Invoke(() => Categories.Add(category));
                 }
             });
@@ -218,7 +218,9 @@ namespace FFXIV_TexTools.ViewModels
                     modPackCatDict.Add(category.Name, category);
                 }
 
-                foreach (var modPackCategory in modPackCatDict)
+                var sortedModPackCatDict = modPackCatDict.OrderBy(i => i.Value.Name);
+
+                foreach (var modPackCategory in sortedModPackCatDict)
                 {
                     List<Mod> modsInModpack;
 
@@ -275,7 +277,7 @@ namespace FFXIV_TexTools.ViewModels
                             category.CategoryList.Add(modItem.name);
 
                         }
-
+                        category.Categories = new ObservableCollection<Category>(category.Categories.OrderBy(i => i.Name));
                         modPackCategory.Value.Categories.Add(category);
                     }
 


### PR DESCRIPTION
Currently items and modpacks are listed in the order in which they were added. This makes navigating the mod list difficult when it contains a large number of mods. I have little experience with UI so if there is a better way to go about this then please let me know. I tested all the functionalities I could think of and it all seemed to work fine.