### PR TITLE
Mod list preview: Replace type field with number field

### DIFF
--- a/FFXIV_TexTools/ViewModels/ModListViewModel.cs
+++ b/FFXIV_TexTools/ViewModels/ModListViewModel.cs
@@ -655,44 +655,43 @@ namespace FFXIV_TexTools.ViewModels
                         {
                             modListModel.Part = "d";
                         }
-                        else if (itemPath.Contains("decal"))
-                        {
-                            modListModel.Part = itemPath.Substring(itemPath.LastIndexOf('_') + 1,
-                                itemPath.LastIndexOf('.') - (itemPath.LastIndexOf('_') + 1));
-                        }
                         else
                         {
                             modListModel.Part = "a";
                         }
 
-                        // Type
-                        if (itemPath.Contains("_iri_"))
+                        // Number
+                        if (itemPath.Contains("/hair"))
                         {
-                            modListModel.Type = XivStrings.Iris;
+                            modListModel.Number = itemPath.Substring(itemPath.IndexOf("/hair") + 8, 3).TrimStart('0');
                         }
-                        else if (itemPath.Contains("_etc_"))
+                        else if (itemPath.Contains("/body"))
                         {
-                            modListModel.Type = XivStrings.Etc;
+                            modListModel.Number = itemPath.Substring(itemPath.IndexOf("/body") + 8, 3).TrimStart('0');
                         }
-                        else if (itemPath.Contains("_fac_"))
+                        else if (itemPath.Contains("/face"))
                         {
-                            modListModel.Type = XivStrings.Face;
+                            modListModel.Number = itemPath.Substring(itemPath.IndexOf("/face") + 8, 3).TrimStart('0');
                         }
-                        else if (itemPath.Contains("_hir_"))
+                        else if (itemPath.Contains("/tail"))
                         {
-                            modListModel.Type = XivStrings.Hair;
+                            modListModel.Number = itemPath.Substring(itemPath.IndexOf("/tail") + 8, 3).TrimStart('0');
                         }
-                        else if (itemPath.Contains("_acc_"))
+                        else if (itemPath.Contains("/zear"))
                         {
-                            modListModel.Type = XivStrings.Accessory;
+                            modListModel.Number = itemPath.Substring(itemPath.IndexOf("/zear") + 8, 3).TrimStart('0');
                         }
-                        else if (itemPath.Contains("demihuman"))
+                        else if (itemPath.Contains("/decal_face"))
                         {
-                            modListModel.Type = itemPath.Substring(itemPath.LastIndexOf('_') - 3, 3);
+                            modListModel.Number = itemPath.Substring(itemPath.IndexOf("/decal_face") + 19, 2).TrimEnd('.');                            
+                        }
+                        else if (itemPath.Contains("/decal_equip") && !itemPath.Contains("stigma"))
+                        {
+                            modListModel.Number = itemPath.Substring(itemPath.IndexOf("/decal_equip") + 20, 3);
                         }
                         else
                         {
-                            modListModel.Type = "--";
+                            modListModel.Number = "--";
                         }
 
                         // Image
@@ -1193,9 +1192,9 @@ namespace FFXIV_TexTools.ViewModels
             public string Part { get; set; }
 
             /// <summary>
-            /// The type of the modded item
+            /// The number of the modded item
             /// </summary>
-            public string Type { get; set; }
+            public string Number { get; set; }
 
             /// <summary>
             /// The brush color reflecting the active status of the modded item

--- a/FFXIV_TexTools/Views/ModListView.xaml
+++ b/FFXIV_TexTools/Views/ModListView.xaml
@@ -104,7 +104,7 @@
 
                                             <Border BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" BorderThickness="1" Grid.Column="1" Grid.Row="3">
                                                 <Viewbox StretchDirection="DownOnly">
-                                                    <Label Content="{Binding Type}"/>
+                                                    <Label Content="{Binding Number}"/>
                                                 </Viewbox>
                                             </Border>
 
@@ -128,7 +128,7 @@
 
                                             <Border Background="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" Grid.Row="2" Grid.Column="1">
                                                 <Viewbox StretchDirection="DownOnly">
-                                                    <Label Content="{Binding Source={x:Static resx:UIStrings.Type}}" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Padding="0"/>
+                                                    <Label Content="{Binding Source={x:Static resx:UIStrings.Num}}" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Padding="0"/>
                                                 </Viewbox>
                                             </Border>
                                         </Grid>


### PR DESCRIPTION
Telling apart mods in the Character category when looking at them in the modlist is currently very difficult. There is tonnes of different hair numbers all shown with the same info in the modlist. To solve this I've gotten rid of the type field of the mod list previews and replaced it with the number. The type field very often only showed "--" and in the cases where it did have information, that information was already shown elsewhere or not very relevant.

Old:
![image](https://user-images.githubusercontent.com/59175928/72690065-c21a9f80-3b18-11ea-962b-2468f426649f.png)

New:
![image](https://user-images.githubusercontent.com/59175928/72690001-09546080-3b18-11ea-9dc0-722854f8ee0b.png)
