### PR TITLE
Option to overwrite existing ModPack

### DIFF
--- a/FFXIV_TexTools/Resources/UIMessages.Designer.cs
+++ b/FFXIV_TexTools/Resources/UIMessages.Designer.cs
@@ -886,6 +886,17 @@ namespace FFXIV_TexTools.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A ModPack with this name already exists.
+        ///
+        ///Would you like to overwrite the existing ModPack?.
+        /// </summary>
+        internal static string ModPackOverwriteMessage {
+            get {
+                return ResourceManager.GetString("ModPackOverwriteMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Location of ModPacks folder changed.
         ///
         ///

--- a/FFXIV_TexTools/Resources/UIMessages.resx
+++ b/FFXIV_TexTools/Resources/UIMessages.resx
@@ -652,4 +652,9 @@ Selecting Yes will add a diffuse map, and selecting No will add a default map.</
   <data name="ModPack_Delete" xml:space="preserve">
     <value>Deleting ModPack</value>
   </data>
+  <data name="ModPackOverwriteMessage" xml:space="preserve">
+    <value>A ModPack with this name already exists.
+
+Would you like to overwrite the existing ModPack?</value>
+  </data>
 </root>

--- a/FFXIV_TexTools/Views/ModPack/ModPackWizard.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/ModPackWizard.xaml.cs
@@ -211,7 +211,26 @@ namespace FFXIV_TexTools.Views
             {
                 var progressIndicator = new Progress<double>(ReportProgress);
                 var texToolsModPack = new TTMP(new DirectoryInfo(Properties.Settings.Default.ModPack_Directory), XivStrings.TexTools);
-                await texToolsModPack.CreateWizardModPack(modPackData, progressIndicator);
+
+                var modPackPath = Path.Combine(Properties.Settings.Default.ModPack_Directory, $"{modPackData.Name}.ttmp2");
+                var overwriteModpack = false;
+
+                if (File.Exists(modPackPath))
+                {
+                    var overwriteDialogResult = FlexibleMessageBox.Show(new Wpf32Window(this), UIMessages.ModPackOverwriteMessage,
+                                                UIMessages.OverwriteTitle, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning);
+                    if (overwriteDialogResult == System.Windows.Forms.DialogResult.Yes)
+                    {
+                        overwriteModpack = true;
+                    }
+                    else if (overwriteDialogResult == System.Windows.Forms.DialogResult.Cancel)
+                    {
+                        await _progressController.CloseAsync();
+                        return;
+                    }
+                }
+
+                await texToolsModPack.CreateWizardModPack(modPackData, progressIndicator, overwriteModpack);
 
                 ModPackFileName = $"{ModPackName.Text}";
             }

--- a/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml.cs
+++ b/FFXIV_TexTools/Views/ModPack/SimpleModPackCreator.xaml.cs
@@ -604,7 +604,25 @@ namespace FFXIV_TexTools.Views
 
             var progressIndicator = new Progress<(int current, int total, string message)>(ReportProgress);
 
-            await texToolsModPack.CreateSimpleModPack(simpleModPackData, _gameDirectory, progressIndicator);
+            var modPackPath = Path.Combine(Properties.Settings.Default.ModPack_Directory, $"{simpleModPackData.Name}.ttmp2");
+            var overwriteModpack = false;
+
+            if (File.Exists(modPackPath))
+            {
+                var overwriteDialogResult = FlexibleMessageBox.Show(new Wpf32Window(this), UIMessages.ModPackOverwriteMessage,
+                                            UIMessages.OverwriteTitle, MessageBoxButtons.YesNoCancel, MessageBoxIcon.Warning);
+                if (overwriteDialogResult == System.Windows.Forms.DialogResult.Yes)
+                {
+                    overwriteModpack = true;
+                }
+                else if (overwriteDialogResult == System.Windows.Forms.DialogResult.Cancel)
+                {
+                    await _progressController.CloseAsync();
+                    return;
+                }
+            }
+
+            await texToolsModPack.CreateSimpleModPack(simpleModPackData, _gameDirectory, progressIndicator, overwriteModpack);
 
             await _progressController.CloseAsync();
 


### PR DESCRIPTION
If a mod pack with the same name already exists, TexTools defaults to renaming the modpack. I've added a dialog to give the user the choice to overwrite the existing modpack, rename the modpack automatically or go back to the modpack creator to manually give it a new name.

![image](https://user-images.githubusercontent.com/59175928/73120606-d6272c80-3f70-11ea-91fa-338b48d41251.png)


Should be merged together with: https://github.com/liinko/xivModdingFramework/pull/34